### PR TITLE
[BS] Specify PNPM Version on Build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
 
       - name: Set up PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
- `build.yml` currently breaks because no PNPM version is specified
