### PR TITLE
[BS] Add startup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "postinstall": "pnpm lefthook install",
-    "dev:client": "next dev",
-    "dev:server": "tsx watch src/infrastructure/server/index.ts",
-    "dev": "dotenvx run -- concurrently --kill-others-on-fail -n client,server -c magenta,cyan \"pnpm run dev:client\" \"pnpm run dev:server\"",
+    "local:client": "next dev",
+    "local:server": "tsx watch src/infrastructure/server/index.ts",
+    "local:all": "pnpm run db:up && dotenvx run -- concurrently --kill-others-on-fail -n client,server -c magenta,cyan \"pnpm run local:client\" \"pnpm run local:server\"",
+    "dev": "tsx run.ts",
     "build:client": "next build",
     "build:server": "tsup",
     "build": "dotenvx run -- concurrently --kill-others-on-fail -n client,server -c magenta,cyan \"pnpm run build:client\" \"pnpm run build:server\"",

--- a/run.ts
+++ b/run.ts
@@ -1,0 +1,37 @@
+import { spawn } from 'child_process'
+
+type Params = {
+    mainCmd: string[]
+    cleanupCmd: string[]
+}
+
+function runWithCleanup({mainCmd, cleanupCmd}: Params) {
+    const child = spawn(mainCmd[0], mainCmd.slice(1), { 
+        shell: true, 
+        stdio: 'inherit' 
+    })
+
+    const cleanup = () => {
+        console.log('\n🧹 Running cleanup...')
+        child.kill()
+        
+        const cleanupProcess = spawn(cleanupCmd[0], cleanupCmd.slice(1), {
+            shell: true,
+            stdio: 'inherit'
+        })
+        
+        cleanupProcess.on('close', () => {
+            console.log('✅ Cleanup complete')
+            process.exit(0)
+        })
+    }
+
+    process.on('SIGINT', cleanup)
+    process.on('SIGTERM', cleanup)
+}
+
+// Usage
+runWithCleanup({
+    mainCmd: ['pnpm', 'run', 'local:all'],
+    cleanupCmd: ['pnpm', 'run', 'db:down']
+})


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
- Allows running and shutting down of dev environment in one command (i.e. `pnpm run dev`)
- On run, it triggers spinning up of the db and starting the app. On cancel, it cleans up by shutting down the db before stopping the app

# Motivation and Context
Why is this change required? What problem does it solve?
- Having to manually run `db:up` and `db:down` to start and shutdown the db was annoying

# Type of Change
Please delete options that are not relevant.
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
- Just run `pnpm run dev` to see it spin up. Cancel it to see the db spin down. You may have to press `Enter` to confirm the shutdown